### PR TITLE
пример обработки ошибок

### DIFF
--- a/AspNetTestApi/Controllers/AccountApiController.cs
+++ b/AspNetTestApi/Controllers/AccountApiController.cs
@@ -1,4 +1,5 @@
-﻿using DomainModel;
+﻿using AspNetTestApi.Handlers;
+using DomainModel;
 using DomainModel.Identity;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -51,7 +52,8 @@ namespace AspNetTestApi.Controllers
         public IActionResult ReadTextAuth()
         {
             if (!User.Identity!.IsAuthenticated)
-                return BadRequest("No login");
+                throw new PlatformException("Unknown user", ErrorTypeEnum.Forbidden);
+            
             string text = "Hello authorized user from AccountApiController";
             return Content(text);
         }

--- a/AspNetTestApi/Handlers/AbstractExceptionHandlerMiddleware.cs
+++ b/AspNetTestApi/Handlers/AbstractExceptionHandlerMiddleware.cs
@@ -1,0 +1,44 @@
+using System.Net;
+
+namespace AspNetTestApi.Handlers;
+
+public abstract class AbstractExceptionHandlerMiddleware
+{
+    public static string LocalizationKey => "LocalizationKey";
+
+    private readonly RequestDelegate _next;
+
+    public abstract (HttpStatusCode code, string message) GetResponse(PlatformException exception);
+
+    public AbstractExceptionHandlerMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task Invoke(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (PlatformException exception)
+        {
+            // Логирование ошибки (не знаю, какой логгер) 
+            // Logger.Error(exception, "error during executing {Context}", context.Request.Path.Value);
+            var response = context.Response;
+            response.ContentType = "application/json";
+
+            // get the response code and message
+            var (status, message) = GetResponse(exception);
+            response.StatusCode = (int)status;
+            await response.WriteAsync(message);
+        }
+        catch (Exception ex)
+        {
+            var response = context.Response;
+            response.ContentType = "application/json";
+            response.StatusCode = 500;
+            await response.WriteAsync($"Unhandled error: {ex.Message}");
+        }
+    }
+}

--- a/AspNetTestApi/Handlers/ErrorTypeEnum.cs
+++ b/AspNetTestApi/Handlers/ErrorTypeEnum.cs
@@ -1,0 +1,10 @@
+namespace AspNetTestApi.Handlers;
+
+public enum ErrorTypeEnum
+{
+    EntityNotFound,
+    Forbidden,
+    Unauthorized,
+    FileNotFound,
+    BadRequest
+}

--- a/AspNetTestApi/Handlers/PlatformException.cs
+++ b/AspNetTestApi/Handlers/PlatformException.cs
@@ -1,0 +1,10 @@
+namespace AspNetTestApi.Handlers;
+
+public class PlatformException : Exception
+{
+    public ErrorTypeEnum ErrorType { get; init; }
+    public PlatformException(string baseMessage, ErrorTypeEnum errorType) : base($"Platform Exception: {baseMessage}")
+    {
+        ErrorType = errorType;
+    }
+}

--- a/AspNetTestApi/Handlers/PlatformExceptionHandlerMiddleware.cs
+++ b/AspNetTestApi/Handlers/PlatformExceptionHandlerMiddleware.cs
@@ -1,0 +1,25 @@
+using System.Net;
+using Microsoft.Extensions.Localization;
+
+namespace AspNetTestApi.Handlers;
+
+public class PlatformExceptionHandlerMiddleware : AbstractExceptionHandlerMiddleware
+{
+    private readonly IStringLocalizer<PlatformExceptionHandlerMiddleware> _localizer;
+    public PlatformExceptionHandlerMiddleware(RequestDelegate next) : base(next)
+    {
+    }
+
+    public override (HttpStatusCode code, string message) GetResponse(PlatformException exception)
+    {
+        var code = exception.ErrorType switch
+        {
+            ErrorTypeEnum.Unauthorized => HttpStatusCode.Unauthorized,
+            ErrorTypeEnum.Forbidden => HttpStatusCode.Forbidden,
+            ErrorTypeEnum.EntityNotFound or ErrorTypeEnum.FileNotFound => HttpStatusCode.NotFound,
+            _ => HttpStatusCode.NotImplemented
+        };
+
+        return (code, exception.Message);
+    }
+}

--- a/AspNetTestApi/Program.cs
+++ b/AspNetTestApi/Program.cs
@@ -1,3 +1,4 @@
+using AspNetTestApi.Handlers;
 using Microsoft.EntityFrameworkCore;
 using DataAccess;
 using DomainModel.Identity;
@@ -57,12 +58,14 @@ internal class Program
 
 
         var app = builder.Build();
-
+        
         // Configure the HTTP request pipeline.
-        if (!app.Environment.IsDevelopment())
-        {
-            app.UseExceptionHandler("/Home/Error");
-        }
+
+        app.UseMiddleware<PlatformExceptionHandlerMiddleware>();
+        // if (!app.Environment.IsDevelopment())
+        // {
+        //     app.UseExceptionHandler("/Home/Error");
+        // }
         app.UseStaticFiles();
 
         app.UseRouting();


### PR DESCRIPTION
коротко о решении: 
1) кастомная ошибка, от нее можно наследоваться и делать другие типы ошибок. Также, сейчас там прокидывается только message, потому что конечному пользователю по сути трейс не нужен, его можно отправить в логи, соответственно логирование надо прикрутить отдельно (для тестового проекта можно хоть просто в файл либо в таблицу бд).  
2) Энам с типами ошибок, в котором ты описываешь разные типы и потом мапишь их к http кодам  
3) Кастомная middleware, обработка ошибок вставляется ВСЕГДА вверх пайплайна http запроса 